### PR TITLE
Correct path to knownWords attribute

### DIFF
--- a/lib/known-words-checker.coffee
+++ b/lib/known-words-checker.coffee
@@ -44,9 +44,9 @@ class KnownWordsChecker
       []
 
   add: (args, target) ->
-    c = atom.config.get 'spell-check.knownWords'
+    c = atom.config.get 'spell-check-test.knownWords'
     c.push target.word
-    atom.config.set 'spell-check.knownWords', c
+    atom.config.set 'spell-check-test.knownWords', c
 
   setAddKnownWords: (newValue) ->
     @enableAdd = newValue


### PR DESCRIPTION
Selecting _Add to Known Words_ from the spelling choices dropdown caused a _"Cannot read property 'push' of undefined"_ error. This was traced to an incorrect path `spell-check.knownWords` to the known words setting in the file `known-words-checker.coffee`.

Steps to reproduce bug:
1. Navigate to misspelt word and activate choices dropdown 
2. Select _Add to Known Words_

**Atom Version**: 1.9.9
**System**: Mac OS X 10.10.5
**Thrown From**: [spell-check-test](https://github.com/dmoonfire/spell-check) package, v0.77.4
### Stack Trace

Uncaught TypeError: Cannot read property 'push' of undefined

```
At /Applications/Atom.app/Contents/Resources/app.asar/node_modules/text-buffer/lib/text-buffer.js:873

TypeError: Cannot read property 'push' of undefined
    at KnownWordsChecker.add (/Users/dominic/.atom/packages/spell-check-test/lib/known-words-checker.coffee:48:6)
    at /Users/dominic/.atom/packages/spell-check-test/lib/corrections-view.coffee:44:21
    at TextBuffer.module.exports.TextBuffer.transact (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/text-buffer/lib/text-buffer.js:868:18)
    at TextEditor.module.exports.TextEditor.transact (/Applications/Atom.app/Contents/Resources/app.asar/src/text-editor.js:1402:26)
    at CorrectionsView.module.exports.CorrectionsView.confirmed (/Users/dominic/.atom/packages/spell-check-test/lib/corrections-view.coffee:26:13)
    at CorrectionsView.module.exports.SelectListView.confirmSelection (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-space-pen-views/lib/select-list-view.js:338:21)
    at space-pen-div.atom.commands.add.core:confirm (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-space-pen-views/lib/select-list-view.js:109:19)
    at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:260:29)
    at /Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:3:61
    at KeymapManager.module.exports.KeymapManager.dispatchCommandEvent (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:580:16)
    at KeymapManager.module.exports.KeymapManager.handleKeyboardEvent (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:388:22)
    at WindowEventHandler.module.exports.WindowEventHandler.handleDocumentKeyEvent (/Applications/Atom.app/Contents/Resources/app.asar/src/window-event-handler.js:98:36)
    at HTMLDocument.<anonymous> (/Applications/Atom.app/Contents/Resources/app.asar/src/window-event-handler.js:3:61)
```
### Commands

```
     -0:02.1.0 spell-check-test:correct-misspelling (atom-text-editor.editor.is-focused)
  4x -0:01.1.0 core:move-down (atom-text-editor.editor.mini.is-focused)
     -0:00.1.0 core:confirm (atom-text-editor.editor.mini.is-focused)
```
### Config

``` json
{
  "core": {
    "disabledPackages": [
      "language-gfm",
      "spell-check",
      "markdown-scroll-sync"
    ],
    "themes": [
      "one-light-ui",
      "one-light-syntax"
    ]
  },
  "spell-check-test": {
    "addKnownWords": true,
    "grammars": [
      "source.asciidoc",
      "source.gfm",
      "text.git-commit",
      "text.plain",
      "text.plain.null-grammar",
      "text.tex.latex",
      "text.md"
    ],
    "knownWords": [
      "monoidal",
      "bicategories",
      "biadjunction",
      "biadjunctions",
      "simplicial",
      "homotopies",
      "homotopically",
      "operads"
    ],
    "locales": [
      "en-GB",
      "en-AU"
    ]
  }
}
```
### Installed Packages

``` coffee
# User
aligner-lua, v1.0.0 (active)
intentions, v1.1.2 (active)
language-lua, v0.9.11 (active)
language-markdown, v0.16.3 (active)
language-rust, v0.4.6 (active)
language-tex, v0.3.0 (active)
latextools, v0.8.2 (active)
linter, v1.11.16 (active)
linter-lua, v1.0.2 (active)
linter-luacheck, v1.1.5 (active)
linter-markdown, v2.0.1 (active)
linter-rust, v0.5.5 (active)
markdown-preview-plus, v2.4.0 (active)
markdown-scroll-sync, v2.1.2 (inactive)
nil-syntax, v0.1.0 (inactive)
nil-ui, v0.2.0 (inactive)
project-plus, v0.9.0 (active)
racer, v0.20.0 (active)
rust-api-docs-helper, v0.5.1 (active)
spell-check-test, v0.77.4 (active)
wordcount, v2.6.2 (active)
atom-dark-syntax, v0.27.0 (inactive)
atom-dark-ui, v0.51.0 (inactive)
atom-light-syntax, v0.28.0 (inactive)
atom-light-ui, v0.43.0 (inactive)
base16-tomorrow-dark-theme, v1.1.0 (inactive)
base16-tomorrow-light-theme, v1.1.1 (inactive)
one-dark-ui, v1.3.2 (inactive)
one-light-ui, v1.3.2 (active)
one-dark-syntax, v1.2.0 (inactive)
one-light-syntax, v1.2.0 (active)
solarized-dark-syntax, v1.0.2 (inactive)
solarized-light-syntax, v1.0.2 (inactive)
about, v1.5.2 (active)
archive-view, v0.61.1 (active)
autocomplete-atom-api, v0.10.0 (active)
autocomplete-css, v0.11.1 (active)
autocomplete-html, v0.7.2 (active)
autocomplete-plus, v2.31.0 (active)
autocomplete-snippets, v1.11.0 (active)
autoflow, v0.27.0 (inactive)
autosave, v0.23.1 (active)
background-tips, v0.26.0 (active)
bookmarks, v0.41.0 (active)
bracket-matcher, v0.82.1 (active)
command-palette, v0.38.0 (inactive)
deprecation-cop, v0.54.1 (active)
dev-live-reload, v0.47.0 (active)
encoding-selector, v0.22.0 (active)
exception-reporting, v0.39.0 (active)
fuzzy-finder, v1.3.0 (active)
git-diff, v1.1.0 (active)
find-and-replace, v0.198.0 (inactive)
go-to-line, v0.31.0 (inactive)
grammar-selector, v0.48.1 (active)
image-view, v0.58.0 (active)
incompatible-packages, v0.26.1 (active)
keybinding-resolver, v0.35.0 (active)
line-ending-selector, v0.5.0 (active)
link, v0.31.1 (inactive)
markdown-preview, v0.158.1 (active)
metrics, v0.53.1 (active)
notifications, v0.64.1 (active)
open-on-github, v1.2.0 (inactive)
package-generator, v1.0.0 (inactive)
settings-view, v0.238.2 (active)
snippets, v1.0.2 (active)
spell-check, v0.67.1 (inactive)
status-bar, v1.4.1 (active)
styleguide, v0.47.1 (active)
symbols-view, v0.113.0 (inactive)
tabs, v0.98.1 (active)
timecop, v0.33.1 (active)
tree-view, v0.208.0 (active)
update-package-dependencies, v0.10.0 (active)
welcome, v0.34.0 (active)
whitespace, v0.32.2 (active)
wrap-guide, v0.38.1 (active)
language-c, v0.52.1 (active)
language-clojure, v0.21.0 (active)
language-coffee-script, v0.47.0 (active)
language-csharp, v0.12.1 (active)
language-css, v0.36.2 (active)
language-gfm, v0.86.0 (inactive)
language-git, v0.13.0 (active)
language-go, v0.42.0 (active)
language-html, v0.44.1 (active)
language-hyperlink, v0.16.0 (active)
language-java, v0.22.0 (active)
language-javascript, v0.119.0 (active)
language-json, v0.18.0 (active)
language-less, v0.29.3 (active)
language-make, v0.22.2 (active)
language-mustache, v0.13.0 (active)
language-objective-c, v0.15.1 (active)
language-perl, v0.35.0 (active)
language-php, v0.37.0 (active)
language-property-list, v0.8.0 (active)
language-python, v0.45.0 (active)
language-ruby, v0.68.5 (active)
language-ruby-on-rails, v0.25.0 (active)
language-sass, v0.52.0 (active)
language-shellscript, v0.22.3 (active)
language-source, v0.9.0 (active)
language-sql, v0.21.1 (active)
language-text, v0.7.1 (active)
language-todo, v0.28.0 (active)
language-toml, v0.18.0 (active)
language-xml, v0.34.8 (active)
language-yaml, v0.26.0 (active)

# Dev
No dev packages
```
